### PR TITLE
fix(common): remove redundant try in ui_bridge

### DIFF
--- a/common/ui_bridge.py
+++ b/common/ui_bridge.py
@@ -150,7 +150,6 @@ def prepare_backtest_data_ui(
     except Exception:
         pass
     try:
-    try:
         ind.log_area.text(tr("indicators: done"))
     except Exception:
         pass


### PR DESCRIPTION
## Summary
- remove leftover `try` causing IndentationError in `ui_bridge`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5ccf49bb88332b220c8156c5dd60f