### PR TITLE
feat(signals): webhook notifications and full-universe default

### DIFF
--- a/app_today_signals.py
+++ b/app_today_signals.py
@@ -18,15 +18,18 @@ settings = get_settings(create_dirs=True)
 with st.sidebar:
     st.header("Universe")
     if st.button("🔁 Rebuild Universe (cached)"):
-        syms = build_universe_from_cache()
+        syms = build_universe_from_cache(limit=None)
         path = save_universe_file(syms)
         st.success(f"Universe updated: {path} ({len(syms)} symbols)")
 
     universe = load_universe_file()
-    default_syms = universe or list(settings.ui.auto_tickers) or []
+    if not universe:
+        universe = build_universe_from_cache(limit=None)
+        save_universe_file(universe)
+    default_syms = universe
     syms_text = st.text_area(
         "Symbols (comma/space separated)",
-        value=", ".join(default_syms[:200]),
+        value=", ".join(default_syms),
         height=100,
     )
     syms = [s.strip().upper() for s in syms_text.replace("\n", ",").replace(" ", ",").split(",") if s.strip()]


### PR DESCRIPTION
## Summary
- default to using the full cached universe when symbols aren't specified
- send signal summaries to Teams/Slack webhooks via `send_signal_notification`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5cd9876d8833292a2a2b33bfb277d