### PR TITLE
Integrate daily scheduler tasks and data updates

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -63,9 +63,18 @@ logging:
 scheduler:
   timezone: America/New_York
   jobs:
+    - name: update_tickers
+      cron: "0 6 * * 1-5"
+      task: update_tickers
+    - name: bulk_last_day
+      cron: "45 6 * * 1-5"
+      task: bulk_last_day
     - name: warm_cache
       cron: "0 7 * * 1-5"    # 平日 07:00
       task: cache_daily_data   # python スクリプト/関数名の想定
+    - name: run_today_signals
+      cron: "15 8 * * 1-5"
+      task: run_today_signals
     - name: send_signals
       cron: "30 8 * * 1-5"   # 平日 08:30
       task: notify_signals

--- a/run_all_systems_today.py
+++ b/run_all_systems_today.py
@@ -212,6 +212,7 @@ def compute_today_signals(
     capital_long: float | None = None,
     capital_short: float | None = None,
     save_csv: bool = False,
+    notify: bool = True,
 ) -> Tuple[pd.DataFrame, Dict[str, pd.DataFrame]]:
     """当日シグナル抽出＋配分の本体。
 
@@ -357,12 +358,13 @@ def compute_today_signals(
         sort_cols = [c for c in ["side", "system", "score"] if c in final_df.columns]
         final_df = final_df.sort_values(sort_cols, ascending=[True, True, True][: len(sort_cols)]).reset_index(drop=True)
 
-        try:
-            from tools.notify_signals import send_signal_notification
+        if notify:
+            try:
+                from tools.notify_signals import send_signal_notification
 
-            send_signal_notification(final_df)
-        except Exception:
-            _log("⚠️ 通知に失敗しました。")
+                send_signal_notification(final_df)
+            except Exception:
+                _log("⚠️ 通知に失敗しました。")
 
     # CSV 保存（任意）
     if save_csv and not final_df.empty:

--- a/schedulers/runner.py
+++ b/schedulers/runner.py
@@ -77,10 +77,40 @@ def task_notify_signals():
     notify_signals()
 
 
+def task_run_today_signals():
+    try:
+        from run_all_systems_today import compute_today_signals
+
+        compute_today_signals(None, save_csv=True, notify=False)
+    except Exception:
+        logging.exception("run_today_signals タスクが失敗しました")
+
+
+def task_bulk_last_day():
+    try:
+        from update_from_bulk_last_day import main as bulk_update
+
+        bulk_update()
+    except Exception:
+        logging.exception("bulk_last_day タスクが失敗しました")
+
+
+def task_update_tickers():
+    try:
+        from tickers_loader import update_ticker_list
+
+        update_ticker_list()
+    except Exception:
+        logging.exception("update_tickers タスクが失敗しました")
+
+
 TASKS: Dict[str, Callable[[], None]] = {
     "cache_daily_data": task_cache_daily_data,
     "warm_cache": task_cache_daily_data,
     "notify_signals": task_notify_signals,
+    "run_today_signals": task_run_today_signals,
+    "bulk_last_day": task_bulk_last_day,
+    "update_tickers": task_update_tickers,
 }
 
 

--- a/tools/notify_signals.py
+++ b/tools/notify_signals.py
@@ -34,16 +34,23 @@ def notify_signals():
         return
 
     total = 0
+    frames = []
     for f in files:
         try:
             df = pd.read_csv(f)
             n = len(df)
             total += n
+            frames.append(df)
             logging.info("シグナル: %s (%d 件)", f.name, n)
         except Exception:
             logging.exception("シグナルCSVの読み込みに失敗: %s", f)
 
     logging.info("本日の合計シグナル件数: %d", total)
+    if frames:
+        try:
+            send_signal_notification(pd.concat(frames, ignore_index=True))
+        except Exception:
+            logging.exception("signal notification failed")
 
 
 def _post_webhook(url: str, text: str) -> None:


### PR DESCRIPTION
## Summary
- Schedule daily ticker refresh, bulk-last-day data update, signal generation, and notifications via YAML and runner tasks
- Allow `compute_today_signals` to skip notification for scheduler pipeline
- Add CLI ticker list updater with webhook notification

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e28331488332b137ca2bdde3676e