### PR TITLE
feat: add cross-system signal merge queue

### DIFF
--- a/common/signal_merge.py
+++ b/common/signal_merge.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+import logging
+
+try:  # pragma: no cover - fallback for older repos
+    from common.progress import log_with_progress  # type: ignore
+except Exception:  # pragma: no cover
+    def log_with_progress(*args, **kwargs):
+        pass
+
+from common.utils import clamp01
+
+try:  # pragma: no cover - optional dependency
+    from common.regime import MarketRegime  # type: ignore
+except Exception:  # pragma: no cover
+    class MarketRegime:  # minimal fallback
+        def __init__(self, state: Dict | None = None):
+            self._state = state or {}
+            self.severity = clamp01(self._state.get("severity", 0.0))
+
+        def is_bearish(self) -> bool:
+            return bool(self._state.get("bearish"))
+
+try:  # pragma: no cover - name compatibility
+    from common.config_loader import load_yaml  # type: ignore
+except Exception:  # pragma: no cover
+    from common.config_loader import load_config_file as load_yaml  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Signal:
+    system_id: int       # 1..7
+    symbol: str
+    side: str            # 'BUY' or 'SELL'
+    strength: float      # raw strength, ~0..1
+    meta: Dict
+
+
+def _score_for_signal(sig: Signal, weights: Dict[str, float], regime: MarketRegime) -> float:
+    meta = sig.meta or {}
+    sid = int(sig.system_id)
+    if sid == 1:
+        w_rank = float(weights.get("w_rank", 0.0))
+        w_trend = float(weights.get("w_trend", 0.0))
+        w_filter = float(weights.get("w_filter", 0.0))
+        rank_pct = clamp01(meta.get("rank_pct_ROC200", 1.0))
+        trend_ok = 1.0 if meta.get("trend_ok") else 0.0
+        spy_ok = 1.0 if meta.get("spy_filter_ok") else 0.0
+        score = w_rank * (1.0 - rank_pct) + w_trend * trend_ok + w_filter * spy_ok
+    elif sid == 2:
+        w_thrust = float(weights.get("w_thrust", 0.0))
+        w_vol = float(weights.get("w_vol", 0.0))
+        w_filter = float(weights.get("w_filter", 0.0))
+        rsi_thrust = clamp01(meta.get("rsi_thrust", 0.0))
+        adx_pct = clamp01(meta.get("adx_pct", 0.0))
+        filt = 1.0 if regime.is_bearish() else 0.0
+        score = w_thrust * rsi_thrust + w_vol * adx_pct + w_filter * filt
+    elif sid == 6:
+        w_trend = float(weights.get("w_trend", 0.0))
+        w_vol = float(weights.get("w_vol", 0.0))
+        w_filter = float(weights.get("w_filter", 0.0))
+        down = clamp01(meta.get("downtrend_strength", 0.0))
+        atr = clamp01(meta.get("atr_norm", 0.0))
+        filt = 1.0 if regime.is_bearish() else 0.0
+        score = w_trend * down + w_vol * atr + w_filter * filt
+    elif sid == 7:
+        score = clamp01(getattr(regime, "severity", 0.0))
+    else:  # 3,4,5
+        w_core = float(weights.get("w_core", 0.0))
+        w_filter = float(weights.get("w_filter", 0.0))
+        strength = clamp01(meta.get("strength", sig.strength))
+        spy_ok = 1.0 if meta.get("spy_filter_ok") else 0.0
+        score = w_core * strength + w_filter * spy_ok
+    return clamp01(score)
+
+
+def merge_signals(all_signals: List[List[Signal]], portfolio_state, market_state) -> List[Dict]:
+    """
+    Build only an execution queue across systems.
+    - Do not filter or block other systems' signals.
+    - If opposite to existing position, always enqueue EXIT then ENTER.
+    - Within the same tier, order by score(desc).
+    """
+
+    signals: List[Signal] = [s for arr in all_signals for s in arr]
+    rules = load_yaml("config/merge_rules.yaml") or {}
+    priority_cfg = {int(k): int(v) for k, v in (rules.get("priority") or {}).items()}
+    scoring_cfg = rules.get("scoring", {})
+    regime = MarketRegime(market_state)
+
+    log_with_progress("merge.start", total=len(signals))
+
+    scored: List[tuple[int, float, Signal]] = []
+    for sig in signals:
+        log_with_progress(
+            "merge.step",
+            increment=1,
+            extra={"symbol": sig.symbol, "sys": sig.system_id, "side": sig.side},
+        )
+        weights = scoring_cfg.get(str(sig.system_id), {})
+        score = _score_for_signal(sig, weights, regime)
+        logger.info(f"[S{sig.system_id}] score={score:.3f} meta={sig.meta}")
+        scored.append((priority_cfg.get(sig.system_id, 999), score, sig))
+
+    scored.sort(key=lambda x: (x[0], -x[1]))
+
+    queue: List[Dict] = []
+    for _, score, sig in scored:
+        existing = (portfolio_state or {}).get(sig.symbol)
+        sig_side = "LONG" if sig.side.upper() == "BUY" else "SHORT"
+        if existing and str(existing).upper() != sig_side:
+            queue.append(
+                {
+                    "action": "EXIT",
+                    "symbol": sig.symbol,
+                    "reason": "reverse_signal",
+                    "system": sig.system_id,
+                }
+            )
+        queue.append(
+            {
+                "action": "ENTER",
+                "symbol": sig.symbol,
+                "side": sig.side,
+                "system": sig.system_id,
+                "score": score,
+            }
+        )
+
+    log_with_progress("merge.done", total=len(queue))
+    return queue
+
+
+__all__ = ["Signal", "merge_signals"]
+

--- a/common/utils.py
+++ b/common/utils.py
@@ -74,3 +74,11 @@ def get_manual_data(symbol: str, folder: str = "data_cache") -> pd.DataFrame:
     get_cached_dataのラッパー
     """
     return get_cached_data(symbol, folder=folder)
+
+
+def clamp01(value: float) -> float:
+    """Clamp numeric value into the 0..1 range."""
+    try:
+        return max(0.0, min(1.0, float(value)))
+    except Exception:
+        return 0.0

--- a/config/merge_rules.yaml
+++ b/config/merge_rules.yaml
@@ -1,0 +1,26 @@
+# 優先度：小さいほど先（=強い）
+priority:
+  "7": 0   # S7 ヘッジ最優先（順序のみ）
+  "6": 1   # S6 トレンド系ショート
+  "2": 2   # S2 RSIスラスト ショート
+  "1": 3   # S1 主力ロング
+  "5": 4   # S5 ロング補助
+  "4": 5   # S4 ロング補助
+  "3": 6   # S3 ロング補助
+
+scoring:
+  "1": { w_rank: 0.6, w_trend: 0.25, w_filter: 0.15 }
+  "2": { w_thrust: 0.5, w_vol: 0.3,  w_filter: 0.2 }
+  "6": { w_trend: 0.55, w_vol: 0.25, w_filter: 0.2 }
+  "7": {}  # regime.severity をそのまま使用
+  "3": { w_core: 0.7, w_filter: 0.3 }
+  "4": { w_core: 0.7, w_filter: 0.3 }
+  "5": { w_core: 0.7, w_filter: 0.3 }
+
+regime:  # スコア補助（順序安定化）
+  bear:
+    spy_roc200_lt: 0.0
+    vix_gt: 22
+  severity:
+    weights: { roc200: 0.5, vix: 0.3, adx: 0.2 }
+

--- a/run_all_systems_today.py
+++ b/run_all_systems_today.py
@@ -21,6 +21,7 @@ from strategies.system4_strategy import System4Strategy
 from strategies.system5_strategy import System5Strategy
 from strategies.system6_strategy import System6Strategy
 from strategies.system7_strategy import System7Strategy
+from common.signal_merge import Signal, merge_signals
 
 
 def _log(msg: str):
@@ -425,6 +426,17 @@ def main():
         ]
         show = [c for c in cols if c in final_df.columns]
         _log(final_df[show].to_string(index=False))
+        signals_for_merge = [
+            Signal(
+                system_id=int(str(r.get("system")).replace("system", "") or 0),
+                symbol=str(r.get("symbol")),
+                side="BUY" if str(r.get("side")).lower() == "long" else "SELL",
+                strength=float(r.get("score") or 0.0),
+                meta={},
+            )
+            for _, r in final_df.iterrows()
+        ]
+        merge_signals([signals_for_merge], portfolio_state={}, market_state={})
         if args.alpaca_submit:
             _submit_orders(final_df, paper=(not args.live), order_type=args.order_type, tif=args.tif)
 


### PR DESCRIPTION
## Summary
- add signal_merge module to order signals by priority and score
- define merge_rules.yaml for priority tiers and scoring weights
- wire run_all_systems_today to invoke merge_signals for execution queue

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e632bc708332be8d456923a4bb69