### PR TITLE
test: cover system1-7 backtest placeholders

### DIFF
--- a/tests/test_system1.py
+++ b/tests/test_system1.py
@@ -28,4 +28,23 @@ def test_prepare_data(dummy_data):
 
 
 def test_placeholder_run(dummy_data):
-    pytest.skip("System1 full backtest inputs require candidate records; skipping")
+    strategy = System1Strategy()
+    # 最小限のデータセットでバックテストを実行
+    dates = pd.date_range("2024-01-01", periods=3, freq="D")
+    df = pd.DataFrame(
+        {
+            "Open": [100, 110, 110],
+            "High": [101, 112, 112],
+            "Low": [99, 108, 100],
+            "Close": [100, 111, 111],
+            "Volume": [1_000_000] * 3,
+            "ATR20": [1, 1, 1],
+        },
+        index=dates,
+    )
+    prepared = {"DUMMY": df}
+    entry_date = dates[1]
+    candidates = {entry_date: [{"symbol": "DUMMY", "entry_date": entry_date}]}
+    trades = strategy.run_backtest(prepared, candidates, capital=10_000)
+    assert not trades.empty
+    assert "pnl" in trades.columns

--- a/tests/test_system2.py
+++ b/tests/test_system2.py
@@ -28,5 +28,22 @@ def test_minimal_indicators(dummy_data):
 
 
 def test_placeholder_run(dummy_data):
-    # 短期対応: 実バックテストは未完成UIに依存するためスキップ扱い
-    pytest.skip("System2 full backtest integration pending")
+    strategy = System2Strategy()
+    dates = pd.date_range("2024-01-01", periods=3, freq="D")
+    df = pd.DataFrame(
+        {
+            "Open": [100, 110, 110],
+            "High": [101, 112, 120],
+            "Low": [99, 108, 108],
+            "Close": [100, 109, 109],
+            "Volume": [2_000_000] * 3,
+            "ATR10": [1, 1, 1],
+        },
+        index=dates,
+    )
+    prepared = {"DUMMY": df}
+    entry_date = dates[1]
+    candidates = {entry_date: [{"symbol": "DUMMY", "entry_date": entry_date}]}
+    trades = strategy.run_backtest(prepared, candidates, capital=10_000)
+    assert not trades.empty
+    assert "pnl" in trades.columns

--- a/tests/test_system3.py
+++ b/tests/test_system3.py
@@ -26,4 +26,22 @@ def test_minimal_indicators(dummy_data):
 
 
 def test_placeholder_run(dummy_data):
-    pytest.skip("System3 full backtest integration pending")
+    strategy = System3Strategy()
+    dates = pd.date_range("2024-01-01", periods=4, freq="D")
+    df = pd.DataFrame(
+        {
+            "Open": [100, 95, 100, 101],
+            "High": [100, 95, 100, 101],
+            "Low": [100, 95, 100, 101],
+            "Close": [100, 95, 100, 101],
+            "Volume": [1_500_000] * 4,
+            "ATR10": [1, 1, 1, 1],
+        },
+        index=dates,
+    )
+    prepared = {"DUMMY": df}
+    entry_date = dates[1]
+    candidates = {entry_date: [{"symbol": "DUMMY", "entry_date": entry_date}]}
+    trades = strategy.run_backtest(prepared, candidates, capital=10_000)
+    assert not trades.empty
+    assert "pnl" in trades.columns

--- a/tests/test_system4.py
+++ b/tests/test_system4.py
@@ -26,4 +26,22 @@ def test_minimal_indicators(dummy_data):
 
 
 def test_placeholder_run(dummy_data):
-    pytest.skip("System4 full backtest integration pending")
+    strategy = System4Strategy()
+    dates = pd.date_range("2024-01-01", periods=3, freq="D")
+    df = pd.DataFrame(
+        {
+            "Open": [100, 100, 100],
+            "High": [101, 101, 101],
+            "Low": [99, 99, 90],
+            "Close": [100, 100, 90],
+            "Volume": [2_000_000] * 3,
+            "ATR40": [1, 1, 1],
+        },
+        index=dates,
+    )
+    prepared = {"DUMMY": df}
+    entry_date = dates[1]
+    candidates = {entry_date: [{"symbol": "DUMMY", "entry_date": entry_date}]}
+    trades = strategy.run_backtest(prepared, candidates, capital=10_000)
+    assert not trades.empty
+    assert "pnl" in trades.columns

--- a/tests/test_system5.py
+++ b/tests/test_system5.py
@@ -26,4 +26,22 @@ def test_minimal_indicators(dummy_data):
 
 
 def test_placeholder_run(dummy_data):
-    pytest.skip("System5 full backtest integration pending")
+    strategy = System5Strategy()
+    dates = pd.date_range("2024-01-01", periods=4, freq="D")
+    df = pd.DataFrame(
+        {
+            "Open": [100, 100, 100, 99],
+            "High": [100, 100, 100, 99],
+            "Low": [100, 90, 90, 99],
+            "Close": [100, 97, 99, 99],
+            "Volume": [1_000_000] * 4,
+            "ATR10": [1, 1, 1, 1],
+        },
+        index=dates,
+    )
+    prepared = {"DUMMY": df}
+    entry_date = dates[1]
+    candidates = {entry_date: [{"symbol": "DUMMY", "entry_date": entry_date}]}
+    trades = strategy.run_backtest(prepared, candidates, capital=10_000)
+    assert not trades.empty
+    assert "pnl" in trades.columns

--- a/tests/test_system6.py
+++ b/tests/test_system6.py
@@ -26,4 +26,22 @@ def test_minimal_indicators(dummy_data):
 
 
 def test_placeholder_run(dummy_data):
-    pytest.skip("System6 full backtest integration pending")
+    strategy = System6Strategy()
+    dates = pd.date_range("2024-01-01", periods=4, freq="D")
+    df = pd.DataFrame(
+        {
+            "Open": [100, 100, 100, 100],
+            "High": [100, 100, 100, 100],
+            "Low": [100, 100, 100, 100],
+            "Close": [100, 105, 90, 95],
+            "Volume": [1_000_000] * 4,
+            "ATR10": [1, 1, 1, 1],
+        },
+        index=dates,
+    )
+    prepared = {"DUMMY": df}
+    entry_date = dates[1]
+    candidates = {entry_date: [{"symbol": "DUMMY", "entry_date": entry_date}]}
+    trades = strategy.run_backtest(prepared, candidates, capital=10_000)
+    assert not trades.empty
+    assert "pnl" in trades.columns

--- a/tests/test_system7.py
+++ b/tests/test_system7.py
@@ -26,4 +26,23 @@ def test_minimal_indicators(dummy_data):
 
 
 def test_placeholder_run(dummy_data):
-    pytest.skip("System7 full backtest integration pending")
+    strategy = System7Strategy()
+    dates = pd.date_range("2024-01-01", periods=4, freq="D")
+    df = pd.DataFrame(
+        {
+            "Open": [100, 100, 100, 100],
+            "High": [100, 100, 110, 100],
+            "Low": [100, 100, 100, 100],
+            "Close": [100, 100, 100, 100],
+            "Volume": [1_000_000] * 4,
+            "ATR50": [1, 1, 1, 1],
+            "max_70": [150, 150, 150, 150],
+        },
+        index=dates,
+    )
+    prepared = {"SPY": df}
+    entry_date = dates[1]
+    candidates = {entry_date: [{"symbol": "SPY", "entry_date": entry_date, "ATR50": 1}]}
+    trades = strategy.run_backtest(prepared, candidates, capital=10_000)
+    assert not trades.empty
+    assert "pnl" in trades.columns


### PR DESCRIPTION
## Summary
- replace placeholder skips with real backtest runs in `tests/test_system1-7.py`
- construct minimal OHLCV datasets and candidate maps to exercise `run_backtest`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b715270984833280a11f59b8cf23c6