### PR TITLE
fix(common): add fallback text to Slack webhook notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@
 - 初期: 開発ツール導入（pre-commit, ruff, black, isort, mypy）
 - CI 追加（lint/type/security/test）
 - ドキュメント整備（AGENTS.md, .env.example）
-
+- Slack通知が送信されない問題を修正（textフィールドを追加）


### PR DESCRIPTION
## Summary
- ensure Slack messages include fallback text to satisfy webhook requirements
- document Slack notification fix in changelog

## Testing
- `pre-commit run ruff --files common/notifier.py CHANGELOG.md`
- `pre-commit run ruff-format --files common/notifier.py CHANGELOG.md`
- `pre-commit run black --files common/notifier.py CHANGELOG.md`
- `pre-commit run isort --files common/notifier.py`
- `pre-commit run end-of-file-fixer --files common/notifier.py CHANGELOG.md`
- `pre-commit run trailing-whitespace --files common/notifier.py CHANGELOG.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b859e7ffe4833281c31cb9d4526d0e