### PR TITLE
docs: instruct codex to run tests after each task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,9 @@
 - 使用: コミット時に `ruff`/`black`/`isort`/基本フックが自動実行。
 
 ## Testing Guidelines
+- Codex タスク後は以下のコマンドでテストを実行し、異常がないか確認すること:
+  - `pre-commit run --files tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
+  - `pytest tests/test_headless_app.py tests/test_utils.py -q`
 - フレームワーク: `pytest`。決定性重視（乱数シード・日付固定）。
 - ネットワーク呼び出しは避け、キャッシュ済みデータを使用。
 - 実行: `pytest -q`。失敗時は対象を絞ってデバッグ。

--- a/tests/app_smoke.py
+++ b/tests/app_smoke.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+import app_integrated as app
+
+settings = SimpleNamespace(
+    RESULTS_DIR=Path("results"),
+    LOGS_DIR=Path("logs"),
+    DATA_CACHE_DIR=Path("data_cache"),
+    THREADS_DEFAULT=1,
+    ui=SimpleNamespace(default_capital=100000),
+    logging=SimpleNamespace(level="INFO"),
+)
+app.get_settings = lambda create_dirs=True: settings
+
+
+class DummyLogger:
+    def info(self, *args, **kwargs):
+        pass
+
+    def exception(self, *args, **kwargs):
+        pass
+
+
+def _dummy_logger(_: SimpleNamespace) -> DummyLogger:
+    return DummyLogger()
+
+
+app.setup_logging = _dummy_logger
+app.Notifier = lambda platform="auto": object()
+app.get_spy_data_cached = lambda: None
+app.render_integrated_tab = lambda *args, **kwargs: None
+app.render_batch_tab = lambda *args, **kwargs: None
+
+for i in range(1, 8):
+    mod = ModuleType(f"app_system{i}")
+    mod.run_tab = lambda *args, **kwargs: None
+    sys.modules[f"app_system{i}"] = mod
+
+app.main()

--- a/tests/test_headless_app.py
+++ b/tests/test_headless_app.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import socket
+import subprocess
+import time
+
+import pytest
+import requests
+
+
+def _get_free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def test_streamlit_smoke_headless() -> None:
+    port = _get_free_port()
+    root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(root)
+    cmd = [
+        "streamlit",
+        "run",
+        str(root / "tests" / "app_smoke.py"),
+        "--server.port",
+        str(port),
+        "--server.headless",
+        "true",
+    ]
+    proc = subprocess.Popen(
+        cmd, cwd=root, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    )
+    try:
+        url = f"http://localhost:{port}"
+        for _ in range(20):
+            try:
+                resp = requests.get(url)
+                if resp.status_code == 200:
+                    break
+            except requests.ConnectionError:
+                time.sleep(0.5)
+        else:
+            output = proc.stdout.read().decode("utf-8", errors="ignore")
+            pytest.fail(f"Streamlit did not start: {output}")
+        assert resp.status_code == 200
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import pytest
+
+from common.utils import clamp01
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [(-1, 0.0), (0.5, 0.5), (2, 1.0), ("bad", 0.0)],
+)
+def test_clamp01(value: float | str, expected: float) -> None:
+    assert clamp01(value) == expected


### PR DESCRIPTION
## Summary
- document that Codex must run pre-commit and pytest after each task

## Testing
- `pre-commit run --files AGENTS.md`
- `pytest tests/test_headless_app.py tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8624df2288332a61aeb0833f738ca