### PR TITLE
Enable coverage measurement in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,5 @@ lint.ignore = [
   "N806",
 ]
 
+[tool.pytest.ini_options]
+addopts = "--cov=./ --cov-report=term-missing"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,5 @@ pip-audit>=2.7,<3
 
 # Testing helpers
 pytest>=8,<9
+pytest-cov>=5,<6
 freezegun>=1.5,<2
-


### PR DESCRIPTION
## Summary
- add pytest-cov dependency
- configure pytest to collect coverage by default

## Testing
- `pre-commit run --files pyproject.toml requirements-dev.txt tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_headless_app.py tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b99e535610833298db060d994e6e67