### PR TITLE
fix: enforce UTF-8 stdout to prevent cp932 errors

### DIFF
--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,2 +1,23 @@
-"""Common utilities and components package."""
+"""Common utilities and components package.
 
+このパッケージをインポートしたタイミングで標準出力／標準エラーを UTF-8
+に再設定し、Windows などで発生する CP932 由来のエンコードエラーを回避する。
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def _ensure_utf8() -> None:
+    """Reconfigure stdout/stderr to UTF-8 if possible."""
+
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            # `reconfigure` が利用できない環境ではそのまま継続
+            pass
+
+
+_ensure_utf8()

--- a/recover_spy_cache.py
+++ b/recover_spy_cache.py
@@ -1,8 +1,14 @@
+"""SPY の日足データを取得しローカルキャッシュに保存するスクリプト."""
+
+# ruff: noqa: I001
 import os
 import sys
+
+from dotenv import load_dotenv
 import pandas as pd
 import requests
-from dotenv import load_dotenv
+
+import common  # noqa: F401
 
 # .envからAPIキー取得
 load_dotenv()


### PR DESCRIPTION
## Summary
- enforce UTF-8 on stdout/stderr when importing `common`
- ensure `recover_spy_cache` initializes UTF-8 and document script purpose

## Testing
- `pre-commit run --files common/__init__.py recover_spy_cache.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba3aa8c5948332a78c86a50cb31bef