### PR TITLE
refactor: simplify backtest notification handling

### DIFF
--- a/app_system1.py
+++ b/app_system1.py
@@ -17,6 +17,7 @@ from common.ui_components import (
     display_roc200_ranking,
     run_backtest_app,
     save_signal_and_trade_logs,
+    show_results,
     show_signal_trade_summary,
 )
 import common.ui_patch  # noqa: F401
@@ -35,7 +36,6 @@ DISPLAY_NAME = "システム1"
 strategy = System1Strategy()
 # Auto-select Slack/Discord based on available webhook env
 notifiers = get_notifiers_from_env()
-notifier = notifiers[0]
 
 
 def run_tab(spy_df=None, ui_manager=None):
@@ -117,17 +117,14 @@ def run_tab(spy_df=None, ui_manager=None):
             for n in notifiers:
                 try:
                     mention = "channel" if n.platform == "slack" else None
-                    if hasattr(n, "send_backtest_ex"):
-                        n.send_backtest_ex(
-                            "system1",
-                            period,
-                            stats,
-                            ranking,
-                            image_url=img_url,
-                            mention=mention,
-                        )
-                    else:
-                        n.send_backtest("system1", period, stats, ranking)
+                    n.send_backtest_ex(
+                        "system1",
+                        period,
+                        stats,
+                        ranking,
+                        image_url=img_url,
+                        mention=mention,
+                    )
                     sent = True
                 except Exception:
                     continue
@@ -149,8 +146,6 @@ def run_tab(spy_df=None, ui_manager=None):
                 prev_merged, prev_res, SYSTEM_NAME, display_name=DISPLAY_NAME
             )
             try:
-                from common.ui_components import show_results
-
                 show_results(prev_res, prev_cap or 0.0, SYSTEM_NAME, key_context="prev")
             except Exception:
                 pass

--- a/common/notifier.py
+++ b/common/notifier.py
@@ -413,23 +413,15 @@ class Notifier:
         stats: dict[str, Any],
         ranking: list[str],
     ) -> None:
-        direction = SYSTEM_POSITION.get(system_name.lower(), "")
-        color = (
-            COLOR_LONG
-            if direction == "long"
-            else COLOR_SHORT if direction == "short" else COLOR_NEUTRAL
-        )
-        title = f"📊 {system_name} バックテスト（{period}, 実行: {now_jst_str()}）"
-        fields = {k: str(v) for k, v in stats.items()}
-        desc = ""
-        if ranking:
-            lines = [f"{i + 1}. {s}" for i, s in enumerate(ranking[:10])]
-            if len(ranking) > 10:
-                lines.append("…")
-            desc = "ROC200 TOP10\n" + "\n".join(lines)
-        self.send(title, desc, fields=fields, color=color)
+        period_with_run = f"{period}, 実行: {now_jst_str()}" if period else f"実行: {now_jst_str()}"
+        self.send_backtest_ex(system_name, period_with_run, stats, ranking)
         summary = ", ".join(f"{k}={v}" for k, v in list(stats.items())[:3])
-        self.logger.info("backtest %s stats=%s top=%d", system_name, summary, min(len(ranking), 10))
+        self.logger.info(
+            "backtest %s stats=%s top=%d",
+            system_name,
+            summary,
+            min(len(ranking), 10),
+        )
 
     def send_trade_report(self, system_name: str, trades: list[dict[str, Any]]) -> None:
         title = f"✅ {system_name} 売買完了（{now_jst_str()}）"


### PR DESCRIPTION
## Summary
- remove unused notifier access in System1 app
- delegate basic backtest notification to extended helper
- consolidate repeated `ui_components` import in System1 app

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba7eeb6afc8332a5e0090019c1f5e2